### PR TITLE
Add Twin Macro Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib/parsers
 lib/processors
 node_modules
+.history

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha all tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["${workspaceRoot}/tests/**/*"],
+      "cwd": "${workspaceRoot}",
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/lib/rules/class-order.js
+++ b/lib/rules/class-order.js
@@ -30,7 +30,7 @@ module.exports = {
     },
   },
 
-  create: function(context) {
+  create: function (context) {
     /**
      * @param {string} classString
      * @param {string[]} sortOrder
@@ -40,9 +40,9 @@ module.exports = {
 
       classArray = [
         ...classArray
-          .filter(item => sortOrder.indexOf(item) !== -1)
+          .filter((item) => sortOrder.indexOf(item) !== -1)
           .sort((a, b) => sortOrder.indexOf(a) - sortOrder.indexOf(b)),
-        ...classArray.filter(item => sortOrder.indexOf(item) === -1),
+        ...classArray.filter((item) => sortOrder.indexOf(item) === -1),
       ]
 
       // Remove duplicates
@@ -57,6 +57,14 @@ module.exports = {
     function getValueNode(node) {
       if (node.attributeValue) {
         return node.attributeValue
+      } else if (
+        node.quasi &&
+        node.quasi.expressions[0] &&
+        node.quasi.expressions[0].quasi
+      ) {
+        return node.quasi.expressions[0].quasi.quasis[0]
+      } else if (node.quasi) {
+        return node.quasi.quasis[0]
       }
 
       return Array.isArray(node.value) ? node.value[0] : node.value
@@ -65,8 +73,41 @@ module.exports = {
     /**
      * @param {ASTNode} node
      */
+    function isValidTaggedTemplateNode(node) {
+      try {
+        if (
+          !node.tag ||
+          (node.tag.object.name !== 'tw' &&
+            node.quasi.expressions[0].tag.name !== 'tw' &&
+            node.tag.name !== 'tw')
+        ) {
+          return false
+        }
+        if (
+          !node.quasi.quasis ||
+          (!node.quasi.quasis[0].value &&
+            !node.quasi.expressions[0].quasi.quasis[0].value)
+        ) {
+          return false
+        }
+      } catch (err) {
+        if (err instanceof TypeError) {
+          return false
+        } else {
+          throw err
+        }
+      }
+      return true
+    }
+
+    /**
+     * @param {ASTNode} node
+     */
     function isValidJSXNode(node) {
-      if (!node.name || ['class', 'className'].indexOf(node.name.name) === -1) {
+      if (
+        !node.name ||
+        ['class', 'className', 'tw'].indexOf(node.name.name) === -1
+      ) {
         return false
       }
       if (!getValueNode(node)) {
@@ -94,9 +135,7 @@ module.exports = {
     }
 
     function parseValue(value) {
-      return String(value)
-        .trim()
-        .replace(/  +/g, ' ')
+      return String(value).trim().replace(/  +/g, ' ')
     }
 
     //----------------------------------------------------------------------
@@ -104,6 +143,21 @@ module.exports = {
     //----------------------------------------------------------------------
 
     return {
+      TaggedTemplateExpression(node) {
+        if (!isValidTaggedTemplateNode(node)) return
+
+        const valueNode = getValueNode(node)
+        const value = parseValue(valueNode.value.raw)
+        const sortedClasses = sortClassString(value, defaultSortOrder)
+        if (sortedClasses === value) return
+
+        report(node, (fixer) =>
+          fixer.replaceTextRange(
+            [valueNode.range[0] + 1, valueNode.range[1] - 1],
+            sortedClasses
+          )
+        )
+      },
       HTMLAttribute(node) {
         if (node.attributeName.value !== 'class') return
         if (!node.attributeValue.value) return
@@ -113,7 +167,7 @@ module.exports = {
         const sortedClasses = sortClassString(value, defaultSortOrder)
         if (sortedClasses === value) return
 
-        report(node, fixer =>
+        report(node, (fixer) =>
           fixer.replaceTextRange(
             [valueNode.range[0], valueNode.range[1]],
             sortedClasses
@@ -128,7 +182,7 @@ module.exports = {
         const sortedClasses = sortClassString(value, defaultSortOrder)
         if (sortedClasses === value) return
 
-        report(node, fixer =>
+        report(node, (fixer) =>
           fixer.replaceTextRange(
             [getValueNode(node).range[0] + 1, getValueNode(node).range[1] - 1],
             sortedClasses

--- a/tests/lib/rules/class-order.js
+++ b/tests/lib/rules/class-order.js
@@ -18,6 +18,9 @@ const parserOptions = {
 new RuleTester({parserOptions}).run('class-order', rule, {
   valid: [
     {
+      code: '<button tw="flex mt-2 mt-4">Sign In</button>',
+    },
+    {
       code: '<button class="flex mt-2 mt-4">Sign In</button>',
     },
     {
@@ -29,6 +32,16 @@ new RuleTester({parserOptions}).run('class-order', rule, {
     {
       code: '<button class="flex mt-2 mt-4">Sign In</button>',
       parser: parsers.BABEL_ESLINT,
+    },
+    {
+      code: 'tw.div`flex mt-2 mt-4`',
+    },
+    {
+      code: 'tw`flex mt-2 mt-4`',
+    },
+    {
+      code:
+        'const Input = styled.input`\n${tw`flex mt-2 mt-4`}\ncolor: purple;`',
     },
   ],
 
@@ -42,8 +55,33 @@ new RuleTester({parserOptions}).run('class-order', rule, {
       ],
     },
     {
+      code: '<button tw="mt-4 mt-2 flex">Sign In</button>',
+      errors: [
+        {
+          message: 'Invalid class names order',
+        },
+      ],
+    },
+    {
       code: '<button class="mt-4 mt-2 flex">Sign In</button>',
       parser: parsers.BABEL_ESLINT,
+      errors: [
+        {
+          message: 'Invalid class names order',
+        },
+      ],
+    },
+    {
+      code: 'tw.div`mt-4 mt-2 flex`',
+      errors: [
+        {
+          message: 'Invalid class names order',
+        },
+      ],
+    },
+    {
+      code:
+        'const Input = styled.input`\n${tw`mt-4 mt-2 flex`}\ncolor: purple;`',
       errors: [
         {
           message: 'Invalid class names order',


### PR DESCRIPTION
Added twin.macro support to this plugin so we can lint code like:

```jsx
tw.div`flex mt-2`

const hoverStyles = css`
  &:hover {
    border-color: black;
    ${tw`text-black`}
  }
`
```

Fixes #3 