### PR TITLE
Update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript-eslint-parser": "^22.0.0"
   },
   "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Update peerDependencies for eslint to include compatability with eslint version ^7.0.0

Fixes errors when installing eslint with npm or using `npm update`

Closes issue #11 